### PR TITLE
Update Cycle.js counter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ subscribe Rx.Observables and re-render themselves.
 
 ## Counter example
 
-You can compare this example to [Counter example of Cycle.js](https://github.com/cyclejs/cycle-examples/blob/master/counter/src/main.js) and [Counter example of Yolk](https://github.com/yolkjs/yolk#example).
+You can compare this example to [Counter example of Cycle.js](https://github.com/cyclejs/cyclejs/blob/master/examples/basic/counter/src/main.js) and [Counter example of Yolk](https://github.com/yolkjs/yolk#example).
 
 ```javascript
 import { Subject, Observable } from 'rx';


### PR DESCRIPTION
The previous one 404ed due to cycle.js deprecating the examples repo.